### PR TITLE
Change docker-compose.yml to use Postgres

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -23,8 +23,7 @@ services:
       - "5011:8080"
     restart: always
     environment:
-      STORAGE_URI: redis://:${REDIS_PASSWORD}@redis:6379
-      STORAGE_TTL: 2592000000
+      STORAGE_URI: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
 
   excalidraw-room:
     image: excalidraw/excalidraw-room
@@ -32,13 +31,22 @@ services:
     ports:
       - "5012:80"
   
-  redis:
-    image: redis
-    command: redis-server --requirepass ${REDIS_PASSWORD}
-    restart: always
+  postgres:
+    image: postgres:15-alpine
+    # Pass config parameters to the postgres server.
+    # Find more information below when you need to generate the ssl-relevant file your self
+    # command: -c ssl=on -c ssl_cert_file=/var/lib/postgresql/server.crt -c ssl_key_file=/var/lib/postgresql/server.key
+    environment:
+      PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_DB: ${POSTGRES_DB:-excalidraw-prod}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+      POSTGRES_USER: ${POSTGRES_USER}
     volumes:
-      - redis_data:/data
+      - postgres_data:/var/lib/postgresql/data/pgdata
+    #ports:
+    #  - "5432:5432"
 
 volumes:
   notused:
-  redis_data:
+  postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,8 +46,8 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
     volumes:
       - postgres_data:/var/lib/postgresql/data/pgdata
-    ports:
-      - "5432:5432"
+    #ports:
+    #  - "5432:5432"
 volumes:
   postgres_data:
   node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,26 +19,35 @@ services:
       - ./:/opt/node_app/
 
   excalidraw-storage-backend:
-    stdin_open: true
     build: 
       context: https://github.com/kitsteam/excalidraw-storage-backend.git#main
       target: production
+    stdin_open: true
     ports:
       - "8080:8080"
     environment:
-      STORAGE_URI: redis://:${REDIS_PASSWORD}@redis:6379
-      STORAGE_TTL: 2592000000
+      STORAGE_URI: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
 
   excalidraw-room:
     image: excalidraw/excalidraw-room
     ports:
       - "5001:80"
-  
-  redis:
-    image: redis
-    command: redis-server --requirepass ${REDIS_PASSWORD}
+
+  postgres:
+    image: postgres:15-alpine
+    # Pass config parameters to the postgres server.
+    # Find more information below when you need to generate the ssl-relevant file your self
+    # command: -c ssl=on -c ssl_cert_file=/var/lib/postgresql/server.crt -c ssl_key_file=/var/lib/postgresql/server.key
+    environment:
+      PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_DB: ${POSTGRES_DB:-excalidraw-dev}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+      POSTGRES_USER: ${POSTGRES_USER}
     volumes:
-      - redis_data:/data
+      - postgres_data:/var/lib/postgresql/data/pgdata
+    ports:
+      - "5432:5432"
 volumes:
-  redis_data:
+  postgres_data:
   node_modules:


### PR DESCRIPTION
This PR changes the docker-compose.yml and docker-compose-prod.yml to use Postgres instead of Redis.