### PR TITLE
feat: add fallback PUT logic to sync outdated local scene and endpoint call for image update in room

### DIFF
--- a/excalidraw-app/App.tsx
+++ b/excalidraw-app/App.tsx
@@ -438,14 +438,15 @@ const ExcalidrawWrapper = () => {
                 data.key,
                 fileIds,
               );
-          }).then(({ loadedFiles, erroredFiles }) => {
-            excalidrawAPI.addFiles(loadedFiles);
-            updateStaleImageStatuses({
-              excalidrawAPI,
-              erroredFiles,
-              elements: excalidrawAPI.getSceneElementsIncludingDeleted(),
+            })
+            .then(({ loadedFiles, erroredFiles }) => {
+              excalidrawAPI.addFiles(loadedFiles);
+              updateStaleImageStatuses({
+                excalidrawAPI,
+                erroredFiles,
+                elements: excalidrawAPI.getSceneElementsIncludingDeleted(),
+              });
             });
-          });
         } else if (isInitialLoad) {
           if (fileIds.length) {
             LocalData.fileStorage

--- a/excalidraw-app/data/httpStorage.ts
+++ b/excalidraw-app/data/httpStorage.ts
@@ -14,8 +14,7 @@ import { restoreElements } from "../../packages/excalidraw/data/restore";
 import { getSceneVersion } from "../../packages/excalidraw/element";
 import type {
   ExcalidrawElement,
-  FileId,
-  OrderedExcalidrawElement,
+  FileId
 } from "../../packages/excalidraw/element/types";
 import type {
   AppState,

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -6795,7 +6795,7 @@ class App extends React.Component<AppProps, AppState> {
 
     let nextPastePrevented = false;
     const isLinux =
-      typeof window === undefined
+      typeof window === "undefined"
         ? false
         : /Linux/.test(window.navigator.platform);
 


### PR DESCRIPTION
This PR improves the HTTP storage handling:

- Adds fallback PUT logic when local scene is outdated, ensuring changes are synced correctly.
- Updates scene version cache consistently to avoid unnecessary fetches.
- Cleans up imports, logging, and minor type handling for better readability.
- Adds call for endpoint for updating images referenced in a room so that images now follows the room timestamps in db. https://github.com/kitsteam/excalidraw-storage-backend/pull/83

https://github.com/b310-digital/excalidraw/issues/21